### PR TITLE
Fix indentation of invalid_keys deletion

### DIFF
--- a/keyrotator/cleanup.py
+++ b/keyrotator/cleanup.py
@@ -59,10 +59,10 @@ class CleanupCommand(object):
                      key_creation_time)
         invalid_keys.append(key)
 
-      for key in invalid_keys:
-        DeleteCommand().run(project_id, iam_account, key["name"])
+    for key in invalid_keys:
+      DeleteCommand().run(project_id, iam_account, key["name"])
 
-      if not invalid_keys:
-        logging.info("No keys to cleanup.")
+    if not invalid_keys:
+      logging.info("No keys to cleanup.")
 
     return 0


### PR DESCRIPTION
I noticed in repeated usage that the cleanup command was trying to delete keys more than once and failing on additional attempts, and also that the last key could go un-deleted after execution finished.